### PR TITLE
fix 221

### DIFF
--- a/src/compiler/TsNode.ts
+++ b/src/compiler/TsNode.ts
@@ -660,14 +660,14 @@ export class TsNode extends TsSourceFileChild {
             if (this.isNotDisallowedNode(node)) {
                 if (node.kind === ts.SyntaxKind.VariableStatement) {
                     const declarationList = (node as ts.VariableStatement).declarationList;
-                    node = declarationList.declarations[0];
 
-                    if (declarationList.declarations.length > 1) {
-                        Logger.warn(`Unknown situation where declaration list was greater than 1 for ${node.getText(this.sourceFile)}`);
+                    for (const declaredNode of declarationList.declarations) {
+                        callback(this.createNode(declaredNode));
                     }
                 }
-
-                callback(this.createNode(node));
+                else {
+                    callback(this.createNode(node));
+                }
             }
         });
     }

--- a/src/tests/languageTests/variable/variableTests.ts
+++ b/src/tests/languageTests/variable/variableTests.ts
@@ -23,7 +23,7 @@ let myMultilineLet1: number,
     myMultilineLet2;
 
 const myConst: number;
-const myMultilineConst1 = 10,
+const myMultilineConst1: number,
       myMultilineConst2: string;
 `;
 
@@ -93,8 +93,7 @@ const myMultilineConst1 = 10,
         }, {
             name: "myMultilineConst1",
             declarationType: VariableDeclarationType.Const,
-            type: { text: "number" },
-            defaultExpression: { text: "10" }
+            type: { text: "number" }
         }, {
             name: "myMultilineConst2",
             declarationType: VariableDeclarationType.Const,

--- a/src/tests/languageTests/variable/variableTests.ts
+++ b/src/tests/languageTests/variable/variableTests.ts
@@ -10,8 +10,21 @@ describe("variable tests", () => {
 var myImplicitAny;
 var myExplicitTypeVar: number;
 var myImplicitTypeVar = "my string";
+var myMultilineImplicitAny1,
+    myMultilineImplicitAny2,
+    myMultilineImplicitAny3;
+var myMultilineExplicitTypeVar1: boolean,
+    myMultilineExplicitTypeVar2: number;
+var myMultilineImplicitTypeVar1 = "my string",
+    myMultilineImplicitTypeVar2 = 42;
+
 let myLet: string;
+let myMultilineLet1: number,
+    myMultilineLet2;
+
 const myConst: number;
+const myMultilineConst1 = 10,
+      myMultilineConst2: string;
 `;
 
     const def = getInfoFromString(code);
@@ -32,13 +45,60 @@ const myConst: number;
             type: { text: "string" },
             defaultExpression: { text: `"my string"` }
         }, {
+            name: "myMultilineImplicitAny1",
+            declarationType: VariableDeclarationType.Var,
+            type: { text: "any" }
+        }, {
+            name: "myMultilineImplicitAny2",
+            declarationType: VariableDeclarationType.Var,
+            type: { text: "any" }
+        }, {
+            name: "myMultilineImplicitAny3",
+            declarationType: VariableDeclarationType.Var,
+            type: { text: "any" }
+        }, {
+            name: "myMultilineExplicitTypeVar1",
+            declarationType: VariableDeclarationType.Var,
+            type: { text: "boolean" }
+        }, {
+            name: "myMultilineExplicitTypeVar2",
+            declarationType: VariableDeclarationType.Var,
+            type: { text: "number" }
+        }, {
+            name: "myMultilineImplicitTypeVar1",
+            declarationType: VariableDeclarationType.Var,
+            type: { text: "string" },
+            defaultExpression: { text: `"my string"` }
+        }, {
+            name: "myMultilineImplicitTypeVar2",
+            declarationType: VariableDeclarationType.Var,
+            type: { text: "number" },
+            defaultExpression: { text: "42" }
+        }, {
             name: "myLet",
             declarationType: VariableDeclarationType.Let,
             type: { text: "string" }
         }, {
+            name: "myMultilineLet1",
+            declarationType: VariableDeclarationType.Let,
+            type: { text: "number" }
+        }, {
+            name: "myMultilineLet2",
+            declarationType: VariableDeclarationType.Let,
+            type: { text: "any" }
+        }, {
             name: "myConst",
             declarationType: VariableDeclarationType.Const,
             type: { text: "number" }
+        }, {
+            name: "myMultilineConst1",
+            declarationType: VariableDeclarationType.Const,
+            type: { text: "number" },
+            defaultExpression: { text: "10" }
+        }, {
+            name: "myMultilineConst2",
+            declarationType: VariableDeclarationType.Const,
+            type: { text: "string" }
         }]
     });
 });


### PR DESCRIPTION
Iterate over all variable declarations of a `VariableStatement` to support multiline variable statements (see #221)